### PR TITLE
Retry throttling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,14 +44,14 @@
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
   </repositories>
 
   <pluginRepositories>
     <pluginRepository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
 
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>aws-java-sdk</artifactId>
-      <version>1.11.68</version>
+      <version>1.11.264</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>timestamper</artifactId>
-      <version>1.8.7</version>
+      <version>1.8.9</version>
     </dependency>
 
   </dependencies>

--- a/src/main/java/jenkins/plugins/awslogspublisher/AWSLogsBuffer.java
+++ b/src/main/java/jenkins/plugins/awslogspublisher/AWSLogsBuffer.java
@@ -30,7 +30,7 @@ public final class AWSLogsBuffer implements Closeable {
     // ------------------ Do not change this block ------------------
 
     private final BufferedReader reader;
-    private final AWSLogs awsLogs;
+    private final AWSLogs awsLogsClient;
     private final String logGroupName;
     private final String logStreamName;
     private final List<InputLogEvent> list;
@@ -40,9 +40,9 @@ public final class AWSLogsBuffer implements Closeable {
     private String nextSequenceToken;
     private int sequencesSent;
 
-    public AWSLogsBuffer(BufferedReader reader, AWSLogs awsLogs, String logGroupName, String logStreamName, PrintStream logger) {
+    public AWSLogsBuffer(BufferedReader reader, AWSLogs awsLogsClient, String logGroupName, String logStreamName, PrintStream logger) {
         this.reader = reader;
-        this.awsLogs = awsLogs;
+        this.awsLogsClient = awsLogsClient;
         this.logGroupName = logGroupName;
         this.logStreamName = logStreamName;
         this.list = new ArrayList<>();
@@ -101,7 +101,7 @@ public final class AWSLogsBuffer implements Closeable {
         if (this.nextSequenceToken != null) {
             req.setSequenceToken(this.nextSequenceToken);
         }
-        this.nextSequenceToken = awsLogs.putLogEvents(req).getNextSequenceToken();
+        this.nextSequenceToken = awsLogsClient.putLogEvents(req).getNextSequenceToken();
         list.clear();
         currentLogEventCount = 0;
         currentLogEventTotalSize = 0;

--- a/src/main/java/jenkins/plugins/awslogspublisher/AWSLogsHelper.java
+++ b/src/main/java/jenkins/plugins/awslogspublisher/AWSLogsHelper.java
@@ -1,5 +1,8 @@
 package jenkins.plugins.awslogspublisher;
 
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.retry.RetryPolicy;
+import com.amazonaws.retry.PredefinedRetryPolicies;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.AWSCredentialsProvider;
@@ -42,7 +45,7 @@ public final class AWSLogsHelper {
     static String publish(AbstractBuild build, final AWSLogsConfig config, String logStreamName, PrintStream logger) {
 
         try {
-            return pushToAWSLogs(build, getAwsLogs(config), config.getLogGroupName(), logStreamName, logger);
+            return pushToAWSLogs(build, getAwsLogsClient(config), config.getLogGroupName(), logStreamName, logger);
 
         } catch (InterruptedException | IOException e) {
             build.setResult(Result.UNSTABLE);
@@ -50,7 +53,14 @@ public final class AWSLogsHelper {
         }
     }
 
-    private static AWSLogs getAwsLogs(final AWSLogsConfig config) {
+    private static AWSLogs getAwsLogsClient(final AWSLogsConfig config) {
+	    ClientConfiguration AWSconfig = new ClientConfiguration()
+		    .withThrottledRetries(true)
+		    .withConnectionTimeout(6000)
+		    // retryCondition, backoffStrategy(baseDelay, maxBackoffTime), maxErrorRetry, honorMaxErrorRetryInClientConfig
+		    .withRetryPolicy(new RetryPolicy(PredefinedRetryPolicies.DEFAULT_RETRY_CONDITION,
+					    PredefinedRetryPolicies.DEFAULT_BACKOFF_STRATEGY,
+					    10, true));
 
 	    if (!Strings.isNullOrEmpty(config.getAwsAccessKeyId()) && (!Strings.isNullOrEmpty(config.getAwsSecretKey()))) {
 		    AWSCredentials credentials = new AWSCredentials() {
@@ -66,17 +76,20 @@ public final class AWSLogsHelper {
 			    }
 		    };
 
-		    return AWSLogsClientBuilder.standard().
-			    withRegion(config.getAwsRegion()).
-			    withCredentials(new AWSStaticCredentialsProvider(credentials)).
-			    build();
+		    return AWSLogsClientBuilder.standard()
+			    .withClientConfiguration(AWSconfig)
+			    .withRegion(config.getAwsRegion())
+			    .withCredentials(new AWSStaticCredentialsProvider(credentials))
+			    .build();
 	    }
 
 	    // default use DefaultAWSCredentialsProviderChain()
-	    return AWSLogsClientBuilder.standard().build();
+	    return AWSLogsClientBuilder.standard()
+		    .withClientConfiguration(AWSconfig)
+		    .build();
     }
 
-    private static String pushToAWSLogs(AbstractBuild build, AWSLogs awsLogs, String logGroupName, String logStreamName, PrintStream logger)
+    private static String pushToAWSLogs(AbstractBuild build, AWSLogs awsLogsClient, String logGroupName, String logStreamName, PrintStream logger)
             throws IOException, InterruptedException {
 
         if (Strings.isNullOrEmpty(logStreamName)) {
@@ -89,7 +102,7 @@ public final class AWSLogsHelper {
         }
 
         try {
-            awsLogs.createLogStream(new CreateLogStreamRequest(logGroupName, logStreamName));
+            awsLogsClient.createLogStream(new CreateLogStreamRequest(logGroupName, logStreamName));
 
         } catch (Exception e) {
             String errorMsg = String.format("[AWS Logs] Unable to create log stream '%s' in log group '%s' (%s)", logStreamName, logGroupName, e.toString());
@@ -97,7 +110,7 @@ public final class AWSLogsHelper {
             throw new RuntimeException(errorMsg, e);
         }
 
-        try (AWSLogsBuffer buffer = new AWSLogsBuffer(TimestamperAPI.get().read(build, QUERY), awsLogs, logGroupName, logStreamName, logger)) {
+        try (AWSLogsBuffer buffer = new AWSLogsBuffer(TimestamperAPI.get().read(build, QUERY), awsLogsClient, logGroupName, logStreamName, logger)) {
             String line;
             int count = 0;
             Long timestamp = System.currentTimeMillis();
@@ -119,14 +132,12 @@ public final class AWSLogsHelper {
 
                 buffer.add(line, timestamp);
                 count++;
-
             }
 
         } catch (Exception e) {
             String errorMsg = String.format("[AWS Logs] Unable to publish build log to '%s:%s' (%s)", logGroupName, logStreamName, e.toString());
             LOGGER.warning(errorMsg);
             throw new RuntimeException(errorMsg, e);
-
         }
 
         return logStreamName;
@@ -136,5 +147,4 @@ public final class AWSLogsHelper {
     public static String getBuildSpec(AbstractBuild build) {
         return build.getProject().getName() + "/" + build.getNumber();
     }
-
 }

--- a/src/main/java/jenkins/plugins/awslogspublisher/AWSLogsHelper.java
+++ b/src/main/java/jenkins/plugins/awslogspublisher/AWSLogsHelper.java
@@ -54,10 +54,10 @@ public final class AWSLogsHelper {
     }
 
     private static AWSLogs getAwsLogsClient(final AWSLogsConfig config) {
+	    // retryPolicy: retryCondition, backoffStrategy(baseDelay, maxBackoffTime), maxErrorRetry, honorMaxErrorRetryInClientConfig
 	    ClientConfiguration AWSconfig = new ClientConfiguration()
 		    .withThrottledRetries(true)
 		    .withConnectionTimeout(6000)
-		    // retryCondition, backoffStrategy(baseDelay, maxBackoffTime), maxErrorRetry, honorMaxErrorRetryInClientConfig
 		    .withRetryPolicy(new RetryPolicy(PredefinedRetryPolicies.DEFAULT_RETRY_CONDITION,
 					    PredefinedRetryPolicies.DEFAULT_BACKOFF_STRATEGY,
 					    10, true));


### PR DESCRIPTION
When Jenkins is deployed in AWS, the rate logs are put to Cloudwatch is too high.
Occasionally the plugin is throwing
**Caused: java.lang.RuntimeException: [AWS Logs] Unable to publish build log to
'' (com.amazonaws.services.logs.model.AWSLogsException: Rate exceeded (Service:
AWSLogs; Status Code: 400; Error Code: ThrottlingException; Request ID:
9c9a61f4-0281-11e8-a444-9f0a2ce282fe))**

With this PR I'm implementing a Client configuration with support for Throttling and RetryPolicy
I also updated the plugin dependencies and refactored the naming of some vars to be more meaningful.