### PR TITLE
Pipeline step publish_cloudwatch_logs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   </licenses>
 
   <properties>
-    <java.level>7</java.level>
+    <java.level>8</java.level>
   </properties>
 
   <scm>
@@ -67,6 +67,12 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>timestamper</artifactId>
       <version>1.8.9</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-step-api</artifactId>
+      <version>2.15</version>
     </dependency>
 
   </dependencies>

--- a/src/main/java/jenkins/plugins/awslogspublisher/AWSLogsBuffer.java
+++ b/src/main/java/jenkins/plugins/awslogspublisher/AWSLogsBuffer.java
@@ -119,4 +119,8 @@ public final class AWSLogsBuffer implements Closeable {
 
     }
 
+    public void setNextSequenceToken(String nextSequenceToken) {
+		this.nextSequenceToken = nextSequenceToken;
+	}
+
 }

--- a/src/main/java/jenkins/plugins/awslogspublisher/AWSLogsStep.java
+++ b/src/main/java/jenkins/plugins/awslogspublisher/AWSLogsStep.java
@@ -1,18 +1,21 @@
 package jenkins.plugins.awslogspublisher;
 
 import java.io.PrintStream;
+import java.io.Serializable;
 import java.util.Set;
 import java.util.logging.Logger;
 
 import javax.annotation.Nonnull;
 
 import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
 import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 
 import com.google.common.collect.ImmutableSet;
@@ -22,6 +25,7 @@ import hudson.model.Descriptor;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.util.FormValidation;
+import jenkins.model.Jenkins;
 
 public class AWSLogsStep extends Step {
 
@@ -31,8 +35,7 @@ public class AWSLogsStep extends Step {
     private AWSLogsConfig config;
 
     @DataBoundConstructor
-    public AWSLogsStep(String logStreamName, String logGroupName, String awsRegion, String awsAccessKeyId,
-            String awsSecretKey) throws Descriptor.FormException {
+    public AWSLogsStep(String logStreamName) throws Descriptor.FormException {
 
         if (StringUtils.isEmpty(logStreamName)) {
             throw new Descriptor.FormException("cannot be empty", "logStreamName");
@@ -43,18 +46,6 @@ public class AWSLogsStep extends Step {
         this.config = AWSLogsConfig.get();
         if (this.config == null) {
             this.config = new AWSLogsConfig();
-        }
-        if (StringUtils.isNotEmpty(awsRegion)) {
-            this.config.setAwsRegion(awsRegion);
-        }
-        if (StringUtils.isNotEmpty(awsAccessKeyId)) {
-            this.config.setAwsAccessKeyId(awsAccessKeyId);
-        }
-        if (StringUtils.isNotEmpty(awsSecretKey)) {
-            this.config.setAwsSecretKey(awsSecretKey);
-        }
-        if (StringUtils.isNotEmpty(logGroupName)) {
-            this.config.setLogGroupName(logGroupName);
         }
     }
 
@@ -71,7 +62,27 @@ public class AWSLogsStep extends Step {
         return config;
     }
 
-    @Extension
+    @DataBoundSetter
+    public void setAwsRegion(String awsRegion) {
+        this.config.setAwsRegion(awsRegion);
+    }
+
+    @DataBoundSetter
+    public void setAwsAccessKeyId(String awsAccessKeyId) {
+        this.config.setAwsAccessKeyId(awsAccessKeyId);
+    }
+
+    @DataBoundSetter
+    public void setAwsSecretKey(String awsSecretKey) {
+        this.config.setAwsSecretKey(awsSecretKey);
+    }
+
+    @DataBoundSetter
+    public void setLogGroupName(String logGroupName) {
+        this.config.setLogGroupName(logGroupName);
+    }
+
+    @Extension @Symbol("publish_cloudwatch_logs")
     public static class DescriptorImpl extends StepDescriptor {
 
         public DescriptorImpl() {

--- a/src/main/java/jenkins/plugins/awslogspublisher/AWSLogsStep.java
+++ b/src/main/java/jenkins/plugins/awslogspublisher/AWSLogsStep.java
@@ -31,17 +31,30 @@ public class AWSLogsStep extends Step {
     private AWSLogsConfig config;
 
     @DataBoundConstructor
-    public AWSLogsStep(String logGroupName, String logStreamName, String awsRegion, String awsAccessKeyId, String awsSecretKey) throws Descriptor.FormException{
-        this.config = new AWSLogsConfig();
-        this.config.setAwsRegion(awsRegion);
-        this.config.setAwsAccessKeyId(awsAccessKeyId);
-        this.config.setAwsSecretKey(awsSecretKey);
-        if (logGroupName != null && !logGroupName.isEmpty()) {
-            this.config.setLogGroupName(logGroupName);
+    public AWSLogsStep(String logStreamName, String logGroupName, String awsRegion, String awsAccessKeyId,
+            String awsSecretKey) throws Descriptor.FormException {
+
+        if (StringUtils.isEmpty(logStreamName)) {
+            throw new Descriptor.FormException("cannot be empty", "logStreamName");
         }
-        if (logStreamName != null) {
-            // '*' and ':' are not allowed in stream names
-            this.logStreamName = logStreamName.replace('*', '-').replace(':', '-');
+        // '*' and ':' are not allowed in stream names
+        this.logStreamName = logStreamName.replace('*', '-').replace(':', '-');
+
+        this.config = AWSLogsConfig.get();
+        if (this.config == null) {
+            this.config = new AWSLogsConfig();
+        }
+        if (StringUtils.isNotEmpty(awsRegion)) {
+            this.config.setAwsRegion(awsRegion);
+        }
+        if (StringUtils.isNotEmpty(awsAccessKeyId)) {
+            this.config.setAwsAccessKeyId(awsAccessKeyId);
+        }
+        if (StringUtils.isNotEmpty(awsSecretKey)) {
+            this.config.setAwsSecretKey(awsSecretKey);
+        }
+        if (StringUtils.isNotEmpty(logGroupName)) {
+            this.config.setLogGroupName(logGroupName);
         }
     }
 

--- a/src/main/java/jenkins/plugins/awslogspublisher/AWSLogsStep.java
+++ b/src/main/java/jenkins/plugins/awslogspublisher/AWSLogsStep.java
@@ -1,0 +1,123 @@
+package jenkins.plugins.awslogspublisher;
+
+import java.io.PrintStream;
+import java.util.Set;
+import java.util.logging.Logger;
+
+import javax.annotation.Nonnull;
+
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+
+import com.google.common.collect.ImmutableSet;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.util.FormValidation;
+
+public class AWSLogsStep extends Step {
+
+    private static Logger LOGGER = Logger.getLogger(AWSLogsStep.class.getName());
+
+    private String logStreamName;
+    private AWSLogsConfig config;
+
+    @DataBoundConstructor
+    public AWSLogsStep(String logGroupName, String logStreamName, String awsRegion, String awsAccessKeyId, String awsSecretKey) throws Descriptor.FormException{
+        this.config = new AWSLogsConfig();
+        this.config.setAwsRegion(awsRegion);
+        this.config.setAwsAccessKeyId(awsAccessKeyId);
+        this.config.setAwsSecretKey(awsSecretKey);
+        if (logGroupName != null && !logGroupName.isEmpty()) {
+            this.config.setLogGroupName(logGroupName);
+        }
+        if (logStreamName != null) {
+            // '*' and ':' are not allowed in stream names
+            this.logStreamName = logStreamName.replace('*', '-').replace(':', '-');
+        }
+    }
+
+    @Override
+    public StepExecution start(StepContext context) throws Exception {
+        return new ExecutionImpl(this, context);
+    }
+
+    public String getLogStreamName() {
+        return logStreamName;
+    }
+
+    public AWSLogsConfig getConfig() {
+        return config;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends StepDescriptor {
+
+        public DescriptorImpl() {
+        }
+
+        @Override
+        public Set<? extends Class<?>> getRequiredContext() {
+            return ImmutableSet.of(Run.class, TaskListener.class);
+        }
+
+        @Override
+        public String getFunctionName() {
+            return "publish_cloudwatch_logs";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Publish build logs to AWS CloudWatch";
+        }
+
+        @SuppressWarnings("unused")
+        public FormValidation doCheckFile(@QueryParameter String value) {
+            if (StringUtils.isBlank(value)) {
+                return FormValidation.error("Needs a value");
+            } else {
+                return FormValidation.ok();
+            }
+        }
+    }
+
+
+    /**
+     * The execution of {@link AWSLogsStep}.
+     */
+    public static class ExecutionImpl extends SynchronousNonBlockingStepExecution<Void> {
+
+        private static final long serialVersionUID = 1L;
+
+        private transient AWSLogsStep step;
+
+        protected ExecutionImpl(@Nonnull AWSLogsStep step, @Nonnull StepContext context) {
+            super(context);
+            this.step = step;
+        }
+
+        @Override
+        protected Void run() throws Exception {
+            Run run = getContext().get(Run.class);
+            PrintStream logger = getContext().get(TaskListener.class).getLogger();
+            final AWSLogsConfig config = step.getConfig();
+
+            try {
+                AWSLogsHelper.publish(run, config, step.getLogStreamName(), logger);
+            } catch (Exception ex) {
+                LOGGER.warning("failed to publish logs to cloudwatch: " + ex.getMessage());
+            }
+
+            return null;
+        }
+    }
+
+}


### PR DESCRIPTION
Adds a new pipeline step called `publish_cloudwatch_logs`, which can be used like so:

```
publish_cloudwatch_logs(logStreamName: "job")
```

Or pass all configs:

```
            publish_cloudwatch_logs(
                logStreamName: "job",
                logGroupName: "testing", 
                awsAccessKeyId: "xxx",
                awsSecretKey: "xxx",
                awsRegion: "us-east-1"
                )
```

Fixes #8, minus the snippet generator